### PR TITLE
440 start stop ezid services

### DIFF
--- a/scripts/start_stop_ezid_services.sh
+++ b/scripts/start_stop_ezid_services.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 action[restart|start|stop]"
+    exit
+fi
+
+case $1 in
+    restart|start|status|stop)
+        ACTION=$1 ;;
+    *) errexit "Action "$1" is not recognized."
+esac
+
+HOSTNSME=`hostname`
+
+echo $HOSTNAME
+
+if [[ "$HOSTNAME" == *"ezid"* && "$HOSTNAME" == *"dev"* ]]; then
+    ENV="dev"
+elif [[ "$HOSTNAME" == *"ezid"* && "$HOSTNAME" == *"stg"* ]]; then
+    ENV="stg"
+elif [[ "$HOSTNAME" == *"ezid"* && "$HOSTNAME" == *"prd"* ]]; then
+    ENV="prd"
+else
+    errexit "Hostname "$HOSTNAME" is not recognized."
+fi
+
+job_list=("ezid")
+job_list_1=(
+"ezid-proc-binder" 
+"ezid-proc-crossref" 
+"ezid-proc-datacite" 
+"ezid-proc-download" 
+"ezid-proc-expunge" 
+"ezid-proc-newsfeed"
+"ezid-proc-search-indexer"
+"ezid-proc-stats")
+job_list_2=(
+"ezid-proc-link-checker" 
+"ezid-proc-link-checker-update")
+
+if [[ $ENV == "stg" ]]; then
+    job_list=("${job_list[@]}" "${job_list_1[@]}")
+elif [[ $ENV == "prd" ]]; then
+    job_list=("${job_list[@]}" "${job_list_1[@]}" "${job_list_2[@]}") 
+fi
+
+for job in "${job_list[@]}"; do
+    CMD="sudo cdlsysctl ${ACTION} ${job}"
+    echo "${CMD}"
+    `${CMD}`
+done
+

--- a/scripts/start_stop_ezid_services.sh
+++ b/scripts/start_stop_ezid_services.sh
@@ -8,12 +8,14 @@ fi
 case $1 in
     restart|start|stop)
         ACTION=$1 ;;
-    *) errexit "Action "$1" is not recognized."
+    *) 
+      echo "Action "$1" is not recognized."
+      exit
 esac
 
 HOSTNSME=`hostname`
 
-echo $HOSTNAME
+echo "On host: $HOSTNAME"
 
 if [[ "$HOSTNAME" == *"ezid"* && "$HOSTNAME" == *"dev"* ]]; then
     ENV="dev"
@@ -22,10 +24,12 @@ elif [[ "$HOSTNAME" == *"ezid"* && "$HOSTNAME" == *"stg"* ]]; then
 elif [[ "$HOSTNAME" == *"ezid"* && "$HOSTNAME" == *"prd"* ]]; then
     ENV="prd"
 else
-    errexit "Hostname "$HOSTNAME" is not recognized."
+    echo "Hostname "$HOSTNAME" is not recognized."
+    exit
 fi
 
 job_list=("ezid")
+
 job_list_1=(
 "ezid-proc-binder" 
 "ezid-proc-crossref" 
@@ -35,6 +39,7 @@ job_list_1=(
 "ezid-proc-newsfeed"
 "ezid-proc-search-indexer"
 "ezid-proc-stats")
+
 job_list_2=(
 "ezid-proc-link-checker" 
 "ezid-proc-link-checker-update")

--- a/scripts/start_stop_ezid_services.sh
+++ b/scripts/start_stop_ezid_services.sh
@@ -6,7 +6,7 @@ if [ $# -ne 1 ]; then
 fi
 
 case $1 in
-    restart|start|status|stop)
+    restart|start|stop)
         ACTION=$1 ;;
     *) errexit "Action "$1" is not recognized."
 esac


### PR DESCRIPTION
@datadavev @rushirajnenuji Hi Dave and Rushiraj,
The 'start_stop_ezid_services.sh' is a wrapper script to start,  stop, restart the EZID service and background jobs on the EZID instances. The background job list is defined by instance name (dev/stg/prd). 
Please review and let me know if you have questions.

Thank you

Jing