### PR TITLE
check cleanup-async-queues job on stg and prd

### DIFF
--- a/scripts/verify_ezid_after_patching.py
+++ b/scripts/verify_ezid_after_patching.py
@@ -9,6 +9,7 @@ import subprocess
 
 BACKGROUND_JOBS_PRD = {
     "ezid-proc-binder": True,
+    "ezid-proc-cleanup-async-queues": True,
     "ezid-proc-crossref": True,
     "ezid-proc-datacite": True,
     "ezid-proc-download": True,
@@ -22,6 +23,7 @@ BACKGROUND_JOBS_PRD = {
 
 BACKGROUND_JOBS_STG = {
     "ezid-proc-binder": True,
+    "ezid-proc-cleanup-async-queues": True,
     "ezid-proc-crossref": True,
     "ezid-proc-datacite": True,
     "ezid-proc-download": True,


### PR DESCRIPTION
@rushirajnenuji Hi Rushiraj,
This is to add the 'cleanup-async-queues' to the job check list. I tested the script on ezid-stg using the 'heck_cleanup_async_queues' branch. The output is attached here. Please review and let me know if you have questions.

Thank you

Jing

Output from ezid-stg:
```
ok 1.1 - Verify EZID status
info 1.2 - EZID version - 3.1.7rc0
ok 2 - Verify search function
## Create identifier
ok 3.1 - doi:10.15697/FK2C053 created
ok 3.2 - doi:10.15697/FK2764K created
ok 3.3 - ark:/99999/fk4709kv4m created
ok 3.4 - doi:10.5072/FK29G5S997 created
ok 3.5 - doi:10.5072/FK25Q52H4D created
ok 3.6 - ark:/99999/fk4378w19h created
ok 3.7 - doi:10.5072/FK21Z4BQ2Q created
ok 3.8 - ark:/99999/fk4zg85d5m created
## Update identifier
ok 4 - ark:/99999/fk4zg85d5m updated with new data: b'_target: https://cdlib.org/services/\n'
## Check background job status
ok 5.1 - ezid-proc-binder active running
ok 5.2 - ezid-proc-cleanup-async-queues active running
ok 5.3 - ezid-proc-crossref active running
ok 5.4 - ezid-proc-datacite active running
ok 5.5 - ezid-proc-download active running
ok 5.6 - ezid-proc-expunge active running
ok 5.7 - ezid-proc-newsfeed active running
ok 5.8 - ezid-proc-search-indexer active running
ok 5.9 - ezid-proc-stats active running
info 5.10 - ezid-proc-link-checker is not running
info 5.11 - ezid-proc-link-checker-update is not running
```