### PR TITLE
add creator and title fields to batch download

### DIFF
--- a/scripts/verify_ezid_status.py
+++ b/scripts/verify_ezid_status.py
@@ -400,12 +400,14 @@ class VerifyEzidStatus:
 
     def check_batch_download(self, notify_email):
         print("## Check batch download from S3")
-        data = {
-            'format': 'csv',
-            'type': 'ark',
-            'column': '_id',
-            'notify': notify_email,
-        }
+        data = [
+            ('format', 'csv'),
+            ('type', 'ark'),
+            ('column', '_id'),
+            ('column', '_mappedCreator'),
+            ('column', '_mappedTitle'),
+            ('notify', notify_email)
+        ]
         url = f"{self.base_url}/download_request"
 
         # post download requst


### PR DESCRIPTION
@sfisher Hi Scott, 
The batch download uses the `Search Identifier` table as data source to generate report. Current test only outputs the `id` field. Adding additional data fields such as title and author fields provides better test coverage. 

We had full-text indexes on the title and author fields. Adding these fields to the test also helped to verify that removing full-text indexes had no impact to query/report performance.

Please take a look and let me know if you have questions.

Thank you

Jing